### PR TITLE
fix(locale): don't try dynamically importing the default locale

### DIFF
--- a/ember-flatpickr/src/components/ember-flatpickr.ts
+++ b/ember-flatpickr/src/components/ember-flatpickr.ts
@@ -133,7 +133,7 @@ export default class EmberFlatpickr extends Component<EmberFlatpickrArgs> {
       Object.entries(rest).filter((entry) => entry[1] !== undefined),
     );
 
-    if (typeof this.args.locale === 'string') {
+    if (typeof this.args.locale === 'string' && this.args.locale !== "en") {
       await import(`flatpickr/dist/l10n/${this.args.locale}.js`);
     }
 


### PR DESCRIPTION
If `"en"` is passed as locale to the `<EmberFlatpickr />` component, the addon will try importing a file `flatpickr/dist/l10n/en.js` which does not exist as English is the default language that is included in the core and doesn't need to be imported additionally.