### PR TITLE
bugfix: Waited for dynamic import to resolve

### DIFF
--- a/ember-flatpickr/package.json
+++ b/ember-flatpickr/package.json
@@ -41,7 +41,8 @@
   },
   "dependencies": {
     "@ember/render-modifiers": "^2.0.3",
-    "@ember/test-helpers": "~3.3.0",
+    "@ember/test-helpers": "^3.3.0",
+    "@ember/test-waiters": "^3.1.0",
     "@embroider/addon-shim": "^1.8.7"
   },
   "devDependencies": {

--- a/ember-flatpickr/src/components/ember-flatpickr.ts
+++ b/ember-flatpickr/src/components/ember-flatpickr.ts
@@ -4,6 +4,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { assert } from '@ember/debug';
 import { scheduleOnce } from '@ember/runloop';
+import { waitForPromise } from '@ember/test-waiters';
 import type { Instance as FlatpickrInstance } from 'flatpickr/dist/types/instance';
 import type { BaseOptions as FlatpickrOptions } from 'flatpickr/dist/types/options';
 import flatpickr from 'flatpickr';
@@ -133,8 +134,10 @@ export default class EmberFlatpickr extends Component<EmberFlatpickrArgs> {
       Object.entries(rest).filter((entry) => entry[1] !== undefined),
     );
 
-    if (typeof this.args.locale === 'string' && this.args.locale !== "en") {
-      await import(`flatpickr/dist/l10n/${this.args.locale}.js`);
+    if (typeof this.args.locale === 'string' && this.args.locale !== 'en') {
+      await waitForPromise(
+        import(`flatpickr/dist/l10n/${this.args.locale}.js`),
+      );
     }
 
     this.flatpickrRef = flatpickr(element, {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,11 @@ importers:
         specifier: ^2.0.3
         version: 2.1.0(@babel/core@7.24.0)(ember-source@5.7.0)
       '@ember/test-helpers':
-        specifier: ~3.3.0
+        specifier: ^3.3.0
         version: 3.3.0(ember-source@5.7.0)(webpack@5.90.3)
+      '@ember/test-waiters':
+        specifier: ^3.1.0
+        version: 3.1.0
       '@embroider/addon-shim':
         specifier: ^1.8.7
         version: 1.8.7

--- a/test-app/tests/integration/components/ember-flatpickr-test.js
+++ b/test-app/tests/integration/components/ember-flatpickr-test.js
@@ -6,8 +6,8 @@ import {
   render,
   find,
   findAll,
+  settled,
   triggerEvent,
-  waitFor,
 } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import {
@@ -431,7 +431,7 @@ module('Integration | Component | ember flatpickr', function (hooks) {
     assert.strictEqual(enabledDays[1].textContent, '25');
   });
 
-  test('locale works correctly', async function (assert) {
+  test('locale as object works correctly', async function (assert) {
     assert.expect(1);
 
     this.set('dateValue', '2080-12-01T16:16:22.585Z');
@@ -463,7 +463,6 @@ module('Integration | Component | ember flatpickr', function (hooks) {
     this.set('dateValue', '2080-12-01T16:16:22.585Z');
     this.set('maxDate', '2080-12-31T16:16:22.585Z');
     this.set('minDate', '2080-12-01T16:16:22.585Z');
-
     this.set('locale', 'fr');
 
     await render(hbs`<EmberFlatpickr
@@ -475,8 +474,6 @@ module('Integration | Component | ember flatpickr', function (hooks) {
       placeholder="Pick date"
     />`);
 
-    await waitFor('.flatpickr-current-month .flatpickr-monthDropdown-month');
-
     assert.strictEqual(
       find(
         '.flatpickr-current-month .flatpickr-monthDropdown-month',
@@ -486,7 +483,7 @@ module('Integration | Component | ember flatpickr', function (hooks) {
     );
   });
 
-  test('onLocaleUpdated fired', async function (assert) {
+  test('onLocaleUpdated (locale as object)', async function (assert) {
     assert.expect(1);
 
     this.set('dateValue', '2080-12-01T16:16:22.585Z');
@@ -504,6 +501,38 @@ module('Integration | Component | ember flatpickr', function (hooks) {
     />`);
 
     this.set('locale', langs.ru);
+    await settled();
+
+    await openFlatpickr();
+
+    assert.strictEqual(
+      find(
+        '.flatpickr-current-month .flatpickr-monthDropdown-month',
+      ).textContent.trim(),
+      'Декабрь',
+      'Russian locale applied successfully',
+    );
+  });
+
+  test('onLocaleUpdated (locale as string)', async function (assert) {
+    assert.expect(1);
+
+    this.set('dateValue', '2080-12-01T16:16:22.585Z');
+    this.set('maxDate', '2080-12-31T16:16:22.585Z');
+    this.set('minDate', '2080-12-01T16:16:22.585Z');
+    this.set('locale', 'fr');
+
+    await render(hbs`<EmberFlatpickr
+      @date={{this.dateValue}}
+      @locale={{this.locale}}
+      @maxDate={{this.maxDate}}
+      @minDate={{this.minDate}}
+      @onChange={{null}}
+      placeholder="Pick date"
+    />`);
+
+    this.set('locale', 'ru');
+    await settled();
 
     await openFlatpickr();
 


### PR DESCRIPTION
## Background

After updating `ember-flatpickr` from version `4.0.0` to `8.0.0`, several rendering and application tests, which assert that the `flatpickr` calendar works (e.g. the user can see the correct date initially, they can click the input to open the calendar and select a date), became flaky.

I believe the reason is, we need translations for Germany to exist (for these assertions to pass) and have been passing the argument `@locale="de"`. Since `ember-flatpickr@>=7.1.0` uses dynamic import to load the translations, tests can fail when loading takes a while. We can see this issue happen by throttling the network when running the tests for `ember-flatpickr`.

<img width="900" alt="" src="https://github.com/user-attachments/assets/0575c404-433c-457c-b57b-c073ede12214">


## Solution

Wrap the dynamic `import()` with `waitForPromise()` from [`@ember/test-waiters`](https://github.com/emberjs/ember-test-waiters), so that tests know when they can resume with the next step.
